### PR TITLE
Remove unnecessary stropts.h include

### DIFF
--- a/core/source/ioput/socket/ip/TcpSocket.cpp
+++ b/core/source/ioput/socket/ip/TcpSocket.cpp
@@ -37,10 +37,6 @@
 
 
 #if __gnu_linux__
-#ifdef __ANDROID__
-#else
-#include <stropts.h>
-#endif
 #include <unistd.h> 
 #include <sys/ioctl.h> 
 


### PR DESCRIPTION
stropts.h isn't available on modern Linux and isn't necessary anyway since it was never implemented.

https://stackoverflow.com/a/61029494/2475176